### PR TITLE
Implement API backend for TeleSpam

### DIFF
--- a/TeleSpam.py
+++ b/TeleSpam.py
@@ -18,6 +18,7 @@ BASE_DIR = os.path.dirname(__file__)
 CONFIG_FILE = os.path.join(BASE_DIR, "session_config.json")
 MESSAGE_FILE = os.path.join(BASE_DIR, "message.txt")
 SESSIONS_DIR = os.path.join(BASE_DIR, "sessions")
+STATE_FILE = os.path.join(BASE_DIR, "state.json")
 os.makedirs(SESSIONS_DIR, exist_ok=True)
 SESSION_NAME = None
 send_mode = "saved"
@@ -51,6 +52,18 @@ def save_config(name, data):
     path = os.path.join(SESSIONS_DIR, f"{name}.json")
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f)
+
+def load_state():
+    global send_mode, interval_minutes
+    if os.path.exists(STATE_FILE):
+        with open(STATE_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        send_mode = data.get("mode", send_mode)
+        interval_minutes = data.get("interval", interval_minutes)
+
+def save_state():
+    with open(STATE_FILE, "w", encoding="utf-8") as f:
+        json.dump({"mode": send_mode, "interval": interval_minutes}, f)
 
 async def authorize():
     clear()
@@ -176,6 +189,7 @@ async def change_target():
         send_target = input("@username или ID: ").strip().lstrip("@")
         send_mode = "one"
         all_dialogs_count = None
+    save_state()
 
 async def change_interval():
     global interval_minutes
@@ -187,9 +201,11 @@ async def change_interval():
             interval_minutes = minutes
     except:
         pass
+    save_state()
 
 async def main():
     global current_user, client_instance, all_dialogs_count
+    load_state()
     app = await init_client()
     async with app:
         client_instance = app

--- a/app.py
+++ b/app.py
@@ -1,7 +1,8 @@
-from flask import Flask, request, render_template
+from flask import Flask, request, jsonify, send_file, render_template
 import sender
 
 app = Flask(__name__)
+
 
 @app.route('/', methods=['GET', 'POST'])
 def index():
@@ -15,6 +16,87 @@ def index():
         sender.run_sender(target.strip(), interval)
         return 'Рассылка запущена'
     return render_template('index.html')
+
+
+@app.post('/send')
+def send():
+    data = request.get_json(force=True)
+    session_name = data.get('session_name')
+    mode = data.get('mode', 'all')
+    interval = float(data.get('interval', 1))
+    try:
+        sender.start_sending(session_name, mode, interval)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 400
+    return jsonify({'status': 'started'})
+
+
+@app.post('/stop')
+def stop():
+    sender.stop_sending()
+    return jsonify({'status': 'stopped'})
+
+
+@app.get('/message')
+def get_message():
+    return send_file(sender.MESSAGE_FILE, mimetype='text/plain; charset=utf-8')
+
+
+@app.post('/message')
+def save_message():
+    text = request.data.decode('utf-8')
+    sender.save_message(text)
+    return jsonify({'status': 'saved'})
+
+
+@app.get('/log')
+def get_log():
+    return jsonify({'log': sender.get_log()})
+
+
+@app.get('/state')
+def get_state():
+    return jsonify(sender.get_state())
+
+
+@app.get('/sessions')
+def get_sessions():
+    return jsonify({'sessions': sender.list_sessions(), 'active': sender.active_session()})
+
+
+@app.post('/sessions/new')
+def create_session():
+    data = request.get_json(force=True)
+    step = data.get('step')
+    name = data.get('session_name')
+    if step == 'start':
+        sender.start_session_creation(name, int(data['api_id']), data['api_hash'])
+        return jsonify({'status': 'ok'})
+    if step == 'phone':
+        sender.send_phone(name, data['phone'])
+        return jsonify({'status': 'code_sent'})
+    if step == 'code':
+        status = sender.confirm_code(name, data['code'])
+        return jsonify({'status': status})
+    if step == 'password':
+        sender.confirm_password(name, data['password'])
+        return jsonify({'status': 'ok'})
+    return jsonify({'error': 'bad step'}), 400
+
+
+@app.post('/sessions/delete')
+def delete_session():
+    data = request.get_json(force=True)
+    sender.delete_session(data['session_name'])
+    return jsonify({'status': 'deleted'})
+
+
+@app.post('/sessions/logout')
+def logout():
+    data = request.get_json(force=True)
+    sender.logout_session(data['session_name'])
+    return jsonify({'status': 'logged_out'})
+
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8080)

--- a/sender.py
+++ b/sender.py
@@ -2,15 +2,222 @@ import os
 import json
 import asyncio
 import threading
+from datetime import datetime
+from typing import Dict, List, Optional
+
 from pyrogram import Client
+from pyrogram.errors import SessionPasswordNeeded
 
 BASE_DIR = os.path.dirname(__file__)
 SESSIONS_DIR = os.path.join(BASE_DIR, "sessions")
 MESSAGE_FILE = os.path.join(BASE_DIR, "message.txt")
+STATE_FILE = os.path.join(BASE_DIR, "state.json")
+
+os.makedirs(SESSIONS_DIR, exist_ok=True)
+
+_log: List[str] = []
+_send_thread: Optional[threading.Thread] = None
+_stop_event = threading.Event()
+_active_session: Optional[str] = None
+
+_pending_sessions: Dict[str, Dict] = {}
 
 
+def _list_sessions() -> List[str]:
+    return [f[:-8] for f in os.listdir(SESSIONS_DIR) if f.endswith(".session")]
+
+
+def _load_message() -> str:
+    if not os.path.exists(MESSAGE_FILE):
+        return ""
+    with open(MESSAGE_FILE, "r", encoding="utf-8") as f:
+        return f.read().strip()
+
+
+def save_message(text: str) -> None:
+    with open(MESSAGE_FILE, "w", encoding="utf-8") as f:
+        f.write(text)
+
+
+def _load_state() -> Dict[str, object]:
+    if not os.path.exists(STATE_FILE):
+        return {"mode": "all", "interval": 1.0}
+    with open(STATE_FILE, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _save_state(mode: Optional[str] = None, interval: Optional[float] = None) -> None:
+    state = _load_state()
+    if mode is not None:
+        state["mode"] = mode
+    if interval is not None:
+        state["interval"] = interval
+    with open(STATE_FILE, "w", encoding="utf-8") as f:
+        json.dump(state, f)
+
+
+def get_message() -> str:
+    return _load_message()
+
+
+def get_log() -> List[str]:
+    return list(_log)
+
+
+def get_state() -> Dict[str, object]:
+    return _load_state()
+
+
+def list_sessions() -> List[str]:
+    return _list_sessions()
+
+
+def _client_for(name: str) -> Client:
+    cfg_path = os.path.join(SESSIONS_DIR, f"{name}.json")
+    if not os.path.exists(cfg_path):
+        raise RuntimeError("session config missing")
+    with open(cfg_path, "r", encoding="utf-8") as f:
+        cfg = json.load(f)
+    return Client(os.path.join(SESSIONS_DIR, name), api_id=cfg["api_id"], api_hash=cfg["api_hash"])
+
+
+async def _sender_loop(session_name: str, mode: str, interval: float) -> None:
+    global _active_session
+    client = _client_for(session_name)
+    message = _load_message()
+    if not message:
+        _log.append("❌ message.txt пуст")
+        return
+    async with client:
+        _active_session = session_name
+        while not _stop_event.is_set():
+            try:
+                if mode == "favorites":
+                    await client.send_message("me", message)
+                    _log.append("✅ favorites")
+                elif mode == "all":
+                    async for dialog in client.get_dialogs():
+                        if _stop_event.is_set():
+                            break
+                        try:
+                            await client.send_message(dialog.chat.id, message)
+                            _log.append(f"✅ {dialog.chat.id}")
+                        except Exception as e:  # pragma: no cover - network related
+                            _log.append(f"❌ {dialog.chat.id}: {e}")
+                        await asyncio.sleep(0.5)
+                else:
+                    try:
+                        await client.send_message(int(mode), message)
+                        _log.append(f"✅ {mode}")
+                    except Exception as e:  # pragma: no cover - network related
+                        _log.append(f"❌ {mode}: {e}")
+                if _stop_event.is_set():
+                    break
+                _log.append("⏳ waiting")
+                await asyncio.sleep(max(1.0, interval))
+            except Exception as e:  # pragma: no cover - network related
+                _log.append(f"❌ loop error: {e}")
+                await asyncio.sleep(interval)
+    _active_session = None
+
+
+def start_sending(session_name: str, mode: str, interval: float) -> None:
+    global _send_thread
+    if _send_thread and _send_thread.is_alive():
+        raise RuntimeError("sender already running")
+    _stop_event.clear()
+    _log.clear()
+    _save_state(mode, interval)
+    thread = threading.Thread(target=lambda: asyncio.run(_sender_loop(session_name, mode, interval)), daemon=True)
+    _send_thread = thread
+    thread.start()
+
+
+def stop_sending() -> None:
+    global _send_thread
+    if _send_thread and _send_thread.is_alive():
+        _stop_event.set()
+        _send_thread.join()
+    _send_thread = None
+    _stop_event.clear()
+
+
+# ---- session management ----
+async def _create_client(session_name: str, api_id: int, api_hash: str) -> Client:
+    client = Client(os.path.join(SESSIONS_DIR, session_name), api_id=api_id, api_hash=api_hash)
+    await client.connect()
+    return client
+
+
+def start_session_creation(session_name: str, api_id: int, api_hash: str) -> None:
+    if session_name in _pending_sessions:
+        raise RuntimeError("creation in progress")
+    client = asyncio.run(_create_client(session_name, api_id, api_hash))
+    _pending_sessions[session_name] = {"client": client, "api_id": api_id, "api_hash": api_hash}
+
+
+def send_phone(session_name: str, phone: str) -> None:
+    state = _pending_sessions.get(session_name)
+    if not state:
+        raise RuntimeError("no such creation")
+    result = asyncio.run(state["client"].send_code(phone))
+    state["phone"] = phone
+    state["phone_code_hash"] = result.phone_code_hash
+
+
+def confirm_code(session_name: str, code: str) -> str:
+    state = _pending_sessions.get(session_name)
+    if not state:
+        raise RuntimeError("no such creation")
+    client = state["client"]
+    try:
+        asyncio.run(client.sign_in(phone_number=state["phone"], phone_code_hash=state["phone_code_hash"], phone_code=code))
+    except SessionPasswordNeeded:
+        state["need_password"] = True
+        return "password"
+    _finish_creation(session_name)
+    return "ok"
+
+
+def confirm_password(session_name: str, password: str) -> None:
+    state = _pending_sessions.get(session_name)
+    if not state or not state.get("need_password"):
+        raise RuntimeError("password not required")
+    client = state["client"]
+    asyncio.run(client.check_password(password))
+    _finish_creation(session_name)
+
+
+def _finish_creation(session_name: str) -> None:
+    state = _pending_sessions.pop(session_name, None)
+    if not state:
+        return
+    client = state["client"]
+    asyncio.run(client.disconnect())
+    cfg_path = os.path.join(SESSIONS_DIR, f"{session_name}.json")
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        json.dump({"api_id": state["api_id"], "api_hash": state["api_hash"], "phone": state.get("phone")}, f)
+
+
+def delete_session(session_name: str) -> None:
+    for ext in (".session", ".session-journal", ".json"):
+        path = os.path.join(SESSIONS_DIR, session_name + ext)
+        if os.path.exists(path):
+            os.remove(path)
+
+
+def logout_session(session_name: str) -> None:
+    client = _client_for(session_name)
+    asyncio.run(client.log_out())
+
+
+def active_session() -> Optional[str]:
+    return _active_session
+
+
+# ---- compatibility with initial CLI ----
 def _get_session():
-    sessions = [f[:-8] for f in os.listdir(SESSIONS_DIR) if f.endswith('.session')]
+    sessions = list_sessions()
     if not sessions:
         print("Нет доступных сессий в", SESSIONS_DIR)
         return None, None
@@ -25,46 +232,11 @@ def _get_session():
     return client, name
 
 
-def _load_message():
-    if not os.path.exists(MESSAGE_FILE):
-        return ""
-    with open(MESSAGE_FILE, "r", encoding="utf-8") as f:
-        return f.read().strip()
-
-
-async def _sender_loop(target: str, interval: float):
-    client, name = _get_session()
-    if not client:
-        return
-    msg = _load_message()
-    if not msg:
-        print("message.txt пуст")
-        return
-    async with client:
-        print(f"\nЗапуск рассылки через сессию {name}. Цель: {target}. Интервал: {interval} сек")
-        while True:
-            try:
-                if target == 'favorites':
-                    await client.send_message("me", msg)
-                    print("Отправлено в Избранное")
-                elif target == 'all':
-                    async for dialog in client.get_dialogs():
-                        try:
-                            await client.send_message(dialog.chat.id, msg)
-                            print("Успешно:", dialog.chat.id)
-                        except Exception as e:
-                            print("Ошибка при отправке", dialog.chat.id, e)
-                        await asyncio.sleep(0.5)
-                else:
-                    await client.send_message(int(target), msg)
-                    print("Отправлено", target)
-                await asyncio.sleep(interval)
-            except Exception as e:
-                print("Ошибка:", e)
-                await asyncio.sleep(interval)
-
-
 def run_sender(target: str, interval: float):
-    thread = threading.Thread(target=lambda: asyncio.run(_sender_loop(target, interval)), daemon=True)
-    thread.start()
-    return thread
+    sessions = list_sessions()
+    if not sessions:
+        print("Нет доступных сессий в", SESSIONS_DIR)
+        return None
+    _save_state(target, interval)
+    start_sending(sessions[0], target, interval)
+    return _send_thread

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,12 +6,36 @@
 </head>
 <body>
     <h1>TeleSpam</h1>
-    <form method="post">
-        <label>Цель рассылки (all, favorites или ID):</label><br>
-        <input type="text" name="target" value="all"><br><br>
+    <form id="sendForm" method="post">
+        <label>Цель рассылки (all или favorites):</label><br>
+        <input type="text" id="mode" value="all" name="target"><br><br>
         <label>Интервал (секунды):</label><br>
-        <input type="number" name="interval" value="60"><br><br>
+        <input type="number" id="interval" value="60" name="interval"><br><br>
+        <label>Сессия:</label><br>
+        <input type="text" id="session" value="account1"><br><br>
         <button type="submit">Запустить рассылку</button>
     </form>
+    <pre id="log"></pre>
+    <script>
+        const form = document.getElementById('sendForm');
+        form.addEventListener('submit', async e => {
+            e.preventDefault();
+            await fetch('/send', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({
+                    session_name: document.getElementById('session').value,
+                    mode: document.getElementById('mode').value,
+                    interval: parseFloat(document.getElementById('interval').value)
+                })
+            });
+        });
+        async function updateLog() {
+            const r = await fetch('/log');
+            const data = await r.json();
+            document.getElementById('log').textContent = data.log.join('\n');
+        }
+        setInterval(updateLog, 2000);
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add asynchronous sender with log and session management
- expose REST API in `app.py` for controlling sending, sessions, and messages
- enhance web UI to use new API
- restore CLI compatibility and share settings between web and console

## Testing
- `python -m py_compile sender.py app.py TeleSpam.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68610f80b50c83319631ef1be31014aa