### PR TITLE
Add basic web interface features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
-sessions/
+sessions/*
+!sessions/.gitkeep

--- a/app.py
+++ b/app.py
@@ -1,20 +1,71 @@
-from flask import Flask, request, render_template
+import argparse
+import os
+from flask import Flask, request, jsonify, render_template
 import sender
+import TeleSpam
 
 app = Flask(__name__)
 
-@app.route('/', methods=['GET', 'POST'])
+active_session = None
+
+def get_default_session():
+    sessions = sender.list_sessions()
+    return sessions[0] if sessions else None
+
+@app.route('/')
 def index():
-    if request.method == 'POST':
-        target = request.form.get('target', 'all')
-        interval = request.form.get('interval', '60')
-        try:
-            interval = float(interval)
-        except ValueError:
-            interval = 60.0
-        sender.run_sender(target.strip(), interval)
-        return 'Рассылка запущена'
     return render_template('index.html')
 
+@app.route('/api/sessions')
+def sessions_api():
+    return jsonify({'sessions': sender.list_sessions(), 'active': sender.current_session})
+
+@app.route('/api/use_session', methods=['POST'])
+def use_session():
+    name = request.json.get('name')
+    if name:
+        sender.current_session = name
+    return jsonify({'ok': True})
+
+@app.route('/api/message', methods=['GET', 'POST'])
+def message_api():
+    if request.method == 'POST':
+        text = request.json.get('text', '')
+        sender.save_message(text)
+        return jsonify({'ok': True})
+    return jsonify({'text': open(sender.MESSAGE_FILE, 'r', encoding='utf-8').read() if os.path.exists(sender.MESSAGE_FILE) else ''})
+
+@app.route('/api/start', methods=['POST'])
+def start():
+    data = request.json
+    target = data.get('target', 'all')
+    interval = float(data.get('interval', 60))
+    session = sender.current_session or get_default_session()
+    if not session:
+        return jsonify({'error': 'no session'}), 400
+    sender.run_sender(session, target, interval)
+    return jsonify({'ok': True})
+
+@app.route('/api/stop', methods=['POST'])
+def stop():
+    sender.stop_sender()
+    return jsonify({'ok': True})
+
+@app.route('/api/logs')
+def logs_api():
+    return jsonify({'logs': sender.get_logs(), 'running': sender.is_running()})
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--console', action='store_true')
+    args = parser.parse_args()
+    if args.console:
+        import asyncio
+        asyncio.run(TeleSpam.main())
+    else:
+        app.run(host='0.0.0.0', port=8080)
+
+
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=8080)
+    main()

--- a/sender.py
+++ b/sender.py
@@ -2,19 +2,31 @@ import os
 import json
 import asyncio
 import threading
+from typing import List
 from pyrogram import Client
 
 BASE_DIR = os.path.dirname(__file__)
 SESSIONS_DIR = os.path.join(BASE_DIR, "sessions")
 MESSAGE_FILE = os.path.join(BASE_DIR, "message.txt")
 
+logs: List[str] = []
+sender_thread: threading.Thread | None = None
+stop_event = threading.Event()
+current_session: str | None = None
 
-def _get_session():
+
+def append_log(text: str):
+    print(text)
+    logs.append(text)
+
+
+def _get_session(name: str | None = None):
     sessions = [f[:-8] for f in os.listdir(SESSIONS_DIR) if f.endswith('.session')]
     if not sessions:
         print("Нет доступных сессий в", SESSIONS_DIR)
         return None, None
-    name = sessions[0]
+    if name is None or name not in sessions:
+        name = sessions[0]
     cfg_path = os.path.join(SESSIONS_DIR, f"{name}.json")
     if not os.path.exists(cfg_path):
         print("Нет конфигурации для", name)
@@ -32,8 +44,17 @@ def _load_message():
         return f.read().strip()
 
 
-async def _sender_loop(target: str, interval: float):
-    client, name = _get_session()
+def save_message(text: str):
+    with open(MESSAGE_FILE, "w", encoding="utf-8") as f:
+        f.write(text)
+
+
+def list_sessions() -> List[str]:
+    return [f[:-8] for f in os.listdir(SESSIONS_DIR) if f.endswith('.session')]
+
+
+async def _sender_loop(session_name: str, target: str, interval: float):
+    client, name = _get_session(session_name)
     if not client:
         return
     msg = _load_message()
@@ -41,30 +62,48 @@ async def _sender_loop(target: str, interval: float):
         print("message.txt пуст")
         return
     async with client:
-        print(f"\nЗапуск рассылки через сессию {name}. Цель: {target}. Интервал: {interval} сек")
-        while True:
+        append_log(f"Запуск рассылки через сессию {name}. Цель: {target}. Интервал: {interval} сек")
+        while not stop_event.is_set():
             try:
                 if target == 'favorites':
                     await client.send_message("me", msg)
-                    print("Отправлено в Избранное")
+                    append_log("Отправлено в Избранное")
                 elif target == 'all':
                     async for dialog in client.get_dialogs():
                         try:
                             await client.send_message(dialog.chat.id, msg)
-                            print("Успешно:", dialog.chat.id)
+                            append_log(f"Успешно: {dialog.chat.id}")
                         except Exception as e:
-                            print("Ошибка при отправке", dialog.chat.id, e)
+                            append_log(f"Ошибка при отправке {dialog.chat.id}: {e}")
                         await asyncio.sleep(0.5)
                 else:
                     await client.send_message(int(target), msg)
-                    print("Отправлено", target)
+                    append_log(f"Отправлено {target}")
                 await asyncio.sleep(interval)
             except Exception as e:
-                print("Ошибка:", e)
+                append_log(f"Ошибка: {e}")
                 await asyncio.sleep(interval)
 
 
-def run_sender(target: str, interval: float):
-    thread = threading.Thread(target=lambda: asyncio.run(_sender_loop(target, interval)), daemon=True)
+def run_sender(session_name: str, target: str, interval: float):
+    global sender_thread, current_session
+    if sender_thread and sender_thread.is_alive():
+        return
+    stop_event.clear()
+    current_session = session_name
+    thread = threading.Thread(target=lambda: asyncio.run(_sender_loop(session_name, target, interval)), daemon=True)
+    sender_thread = thread
     thread.start()
     return thread
+
+
+def stop_sender():
+    stop_event.set()
+
+
+def get_logs() -> List[str]:
+    return logs
+
+
+def is_running() -> bool:
+    return sender_thread is not None and sender_thread.is_alive()

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,15 +3,86 @@
 <head>
     <meta charset="UTF-8">
     <title>TeleSpam</title>
+    <style>
+        body { background:#222; color:#fff; font-family:Arial, sans-serif; }
+        .panel { padding:20px; background:#333; border-radius:8px; margin-bottom:10px; }
+        button { padding:5px 10px; margin:5px; }
+        textarea { width:100%; height:120px; }
+        #logs { white-space:pre-wrap; background:#111; padding:10px; border-radius:8px; height:200px; overflow-y:scroll; }
+    </style>
 </head>
 <body>
-    <h1>TeleSpam</h1>
-    <form method="post">
-        <label>Цель рассылки (all, favorites или ID):</label><br>
-        <input type="text" name="target" value="all"><br><br>
-        <label>Интервал (секунды):</label><br>
-        <input type="number" name="interval" value="60"><br><br>
-        <button type="submit">Запустить рассылку</button>
-    </form>
+<h1>TeleSpam Web</h1>
+<div class="panel">
+    <label>Сессия:</label>
+    <select id="session"></select>
+</div>
+<div class="panel">
+    <textarea id="message"></textarea>
+</div>
+<div class="panel">
+    <label>Цель:</label>
+    <select id="target">
+        <option value="all">Все чаты</option>
+        <option value="favorites">Избранное</option>
+        <option value="id">ID</option>
+    </select>
+    <input type="text" id="targetId" placeholder="ID" style="display:none;" />
+    <label>Интервал (мин):</label>
+    <input type="number" id="interval" value="60" min="1" max="1500" />
+    <button id="start">Старт</button>
+    <button id="stop" style="display:none;">Стоп</button>
+</div>
+<div id="logs" class="panel"></div>
+<script>
+async function loadSessions(){
+    const r=await fetch('/api/sessions');
+    const data=await r.json();
+    const sel=document.getElementById('session');
+    sel.innerHTML='';
+    data.sessions.forEach(s=>{
+        const opt=document.createElement('option');
+        opt.value=s; opt.textContent=s; if(s===data.active) opt.selected=true;
+        sel.appendChild(opt);
+    });
+}
+async function loadMessage(){
+    const r=await fetch('/api/message');
+    const data=await r.json();
+    document.getElementById('message').value=data.text;
+}
+async function saveMessage(){
+    const text=document.getElementById('message').value;
+    await fetch('/api/message',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({text})});
+}
+async function start(){
+    await saveMessage();
+    const session=document.getElementById('session').value;
+    await fetch('/api/use_session',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name:session})});
+    const target=document.getElementById('target').value;
+    let targetVal=target;
+    if(target==='id') targetVal=document.getElementById('targetId').value;
+    const interval=parseFloat(document.getElementById('interval').value)*60;
+    await fetch('/api/start',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({target:targetVal,interval})});
+    document.getElementById('start').style.display='none';
+    document.getElementById('stop').style.display='inline';
+}
+async function stop(){
+    await fetch('/api/stop',{method:'POST'});
+    document.getElementById('start').style.display='inline';
+    document.getElementById('stop').style.display='none';
+}
+async function poll(){
+    const r=await fetch('/api/logs');
+    const data=await r.json();
+    document.getElementById('logs').textContent=data.logs.join('\n');
+    if(data.running) setTimeout(poll,2000);
+}
+
+document.getElementById('start').onclick=()=>{start().then(poll)};
+document.getElementById('stop').onclick=stop;
+document.getElementById('target').onchange=()=>{document.getElementById('targetId').style.display=document.getElementById('target').value==='id'?'inline':'none';};
+window.onload=()=>{loadSessions();loadMessage();};
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- overhaul Flask `app.py` to expose JSON API endpoints for managing sessions, message text and running the sender
- store logs in memory and return them via API
- provide start/stop endpoints and optional console mode
- update sender utilities for session selection and logging
- redesign `templates/index.html` with simple JS interface
- track an empty `sessions/` directory via `.gitkeep`

## Testing
- `python -m py_compile sender.py app.py TeleSpam.py`

------
https://chatgpt.com/codex/tasks/task_e_6863919941508331a20ed023aac7a0e1